### PR TITLE
Add Budget project card

### DIFF
--- a/_tabs/projects.md
+++ b/_tabs/projects.md
@@ -58,6 +58,30 @@ systems.
   <div class="project-card__header">
     <div>
       <p class="project-card__eyebrow">Tangential Solutions</p>
+      <h2>Budget</h2>
+    </div>
+    <a class="project-card__link" href="https://dash.broaddus.app/budget" target="_blank" rel="noopener noreferrer">
+      Open Budget <span aria-hidden="true">↗</span>
+    </a>
+  </div>
+
+  <p>
+    A personal finance app for planning monthly income and category budgets,
+    recording transactions, and seeing at a glance how much remains to spend.
+  </p>
+
+  <ul class="project-card__tags" aria-label="Technologies">
+    <li>Ruby on Rails</li>
+    <li>React</li>
+    <li>TypeScript</li>
+    <li>PostgreSQL</li>
+  </ul>
+</article>
+
+<article class="project-card">
+  <div class="project-card__header">
+    <div>
+      <p class="project-card__eyebrow">Tangential Solutions</p>
       <h2>WebScrape API</h2>
     </div>
     <a class="project-card__link" href="https://github.com/TangentialSolutions/web-scrape-api" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary

- add Budget to the projects page
- link the card to the deployed Budget app
- summarize its monthly planning and transaction-tracking features

## Validation

- `git diff --check`
- Jekyll build not run because the required Ruby 3.4.3 runtime is not installed locally